### PR TITLE
Allowed for a null array of IDs

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -58,6 +58,9 @@ function validateId(doc, refModelName, value, conditions, respond) {
 }
 
 function validateIdArray(doc, refModelName, values, conditions, respond) {
+	  if (values == null) {
+        return respond(true);
+    }    
     if (values.length == 0) {
         return respond(true);
     }


### PR DESCRIPTION
The mongoose-id-validator allows for the vaidation of an array of ID references -- but it doesn't take into account the case where this array might be null -- i.e. if it is optional.  I added a small fix for that scenario in order to make the code work for the application we are working on.