### PR TITLE
Added recursion to validation

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -9,6 +9,10 @@ function idvalidator(schema, options) {
         message = options.message;
     }
 
+    validateLevel(schema, message);
+}
+
+function validateLevel(schema, message) {
     schema.eachPath(function (path, schemaType) {
         var validateFunction = null;
         var refModelName = null;
@@ -32,6 +36,11 @@ function idvalidator(schema, options) {
             schema.path(path).validate(function (value, respond) {
                 validateFunction(this, refModelName, value, conditions, respond);
             }, message);
+        }
+
+        if (schemaType.schema) {
+            // Recurse
+            validateLevel(schemaType.schema, message);
         }
     });
 }


### PR DESCRIPTION
Saw an issue where IDs like user_id in the structure below were not being validated:

{
  name: String,
  users: {
    user_id: {type: Schema.Types.ObjectId, ref: 'User'},
    ...
  }
  ...
}

With this PR, the user_id appears to be validated. Existing tests pass.