### PR TITLE
made changes so that one can enable/disable validation if needed when…

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -18,16 +18,20 @@ IdValidator.prototype.validate = function(schema, options){
     options = options || {};
     var message = options.message || "{PATH} references a non existing ID";
     var connection = options.connection || mongoose;
-    return self.validateSchema(schema, message, connection);
+
+    var caller = (self instanceof IdValidator) ? self : IdValidator.prototype;
+
+    return caller.validateSchema(schema, message, connection);
 }
 
 IdValidator.prototype.validateSchema = function(schema, message, connection) {
     var self = this;
+    var caller = (self instanceof IdValidator) ? self : IdValidator.prototype;
     schema.eachPath(function (path, schemaType) {
 
         //Apply validation recursively to sub-schemas
         if (schemaType.schema) {
-            return validateSchema(schemaType.schema, message, connection);
+            return caller.validateSchema(schemaType.schema, message, connection);
         }
 
         var validateFunction = null;

--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -1,15 +1,28 @@
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
-module.exports = exports = idvalidator;
 
-function idvalidator(schema, options) {
+function IdValidator(){
+    this.enabled = true;
+}
+
+IdValidator.prototype.enable = function(){
+    this.enabled = true;
+}
+
+IdValidator.prototype.disable = function(){
+    this.enabled = false;
+}
+
+IdValidator.prototype.validate = function(schema, options){
+    var self = this;
     options = options || {};
     var message = options.message || "{PATH} references a non existing ID";
     var connection = options.connection || mongoose;
-    validateSchema(schema, message, connection);
+    return self.validateSchema(schema, message, connection);
 }
 
-function validateSchema(schema, message, connection) {
+IdValidator.prototype.validateSchema = function(schema, message, connection) {
+    var self = this;
     schema.eachPath(function (path, schemaType) {
 
         //Apply validation recursively to sub-schemas
@@ -37,7 +50,10 @@ function validateSchema(schema, message, connection) {
 
         if (validateFunction) {
             schema.path(path).validate(function (value, respond) {
-                validateFunction(this, connection, refModelName, value, conditions, respond);
+                if(!(self instanceof IdValidator) || self.enabled){
+                    return validateFunction(this, connection, refModelName, value, conditions, respond);
+                }
+                return respond(true);
             }, message);
         }
 
@@ -73,3 +89,6 @@ function validateIdArray(doc, connection, refModelName, values, conditions, resp
     var query = refModel.count().where('_id')['in'](values);
     executeQuery(query, conditions, values.length, respond);
 }
+
+module.exports = IdValidator.prototype.validate;
+module.exports.getConstructor = IdValidator;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-id-validator",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "Mongoose plugin to validate that ObjectID references refer to objects that actually exist in the referenced collection",
     "author": {
         "name": "Martin Campbell",


### PR DESCRIPTION
Hello,

Basically, we had to find a way to disable validation to ease model tests. That's what I did : I made validator an object, so as to have a boolean telling whether validation should be enabled or not. 

To use it, we basically create a "validator" object, that is applied to schemas we use. Then, all it takes is calling Model.disableValidation or Model.enableValidation to disable or enable validation if needed.

example : 

    var IdValidator = require('mongoose-id-validator').getConstructor;
    function ValidatorConcept(){
    }

    ValidatorConcept.prototype.applyOn = function(){}

    ValidatorConcept.prototype.applyOn = function(schema, options){
        var self = this; 
        var idvalidator = new IdValidator();
        schema.plugin(IdValidator.prototype.validate.bind(idvalidator));

        schema.statics.enableValidation = function(){
            idvalidator.enable();
        }

        schema.statics.disableValidation = function(){
            idvalidator.disable();
        }
    }

Of course, this remains 100 % backward compatible with the old way of using the plugin (do a Model.plugin(require('mongoose-id-validator')) ); the only thing is that you can't enable/disable validation that way.

in short: made changes so that one can enable/disable validation if needed when… using an instance of idvalidator.