### PR TITLE
do not check reference if path was not modified

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -58,7 +58,9 @@ IdValidator.prototype.validateSchema = function (schema, message, connection, al
         if (validateFunction) {
             schema.path(path).validate(function (value, respond) {
 				var conditionsCopy = conditions;
-
+                if(!this.isModified(path)){
+                    return respond(true);
+                }
                 if (!(self instanceof IdValidator) || self.enabled) {
 					if (Object.keys(conditionsCopy).length > 0) {
 						var instance = this;


### PR DESCRIPTION
According to README.md

> Note that the validation method is only executed if the ID value has been updated

Even if ID value has not been updated, the count was still triggered (and so was the validation method).
