### PR TITLE
Using Promise instead of deprecated isAsync

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -60,63 +60,69 @@ IdValidator.prototype.validateSchema = function (
 
         if (validateFunction) {
             schema.path(path).validate({
-                validator: function (value, respond) {
-                    var conditionsCopy = conditions
-                    //A query may not implement an isModified function.
-                    if (this && !!this.isModified && !this.isModified(path)) {
-                        return respond ? respond(true) : true
-                    }
-                    if (!(self instanceof IdValidator) || self.enabled) {
-                        if (Object.keys(conditionsCopy).length > 0) {
-                            var instance = this
-
-                            conditionsCopy = clone(conditions)
-                            traverse(conditionsCopy).forEach(function (value) {
-                                if (typeof value === 'function') {
-                                    this.update(value.call(instance))
-                                }
-                            })
+                validator: function (value) {
+                    return new Promise(function (resolve, reject) {
+                        var conditionsCopy = conditions
+                        //A query may not implement an isModified function.
+                        if (this && !!this.isModified && !this.isModified(path)) {
+                            resolve(true)
+                            return
                         }
-
-                        return validateFunction(this, connection, refModelName,
-                            value, conditionsCopy, respond, allowDuplicates)
-                    }
-                    return respond ? respond(true) : true
+                        if (!(self instanceof IdValidator) || self.enabled) {
+                            if (Object.keys(conditionsCopy).length > 0) {
+                                var instance = this
+    
+                                conditionsCopy = clone(conditions)
+                                traverse(conditionsCopy).forEach(function (value) {
+                                    if (typeof value === 'function') {
+                                        this.update(value.call(instance))
+                                    }
+                                })
+                            }
+    
+                            return validateFunction(this, connection, refModelName,
+                                value, conditionsCopy, resolve, reject, allowDuplicates)
+                        }
+                        resolve(true)
+                        return
+                    }.bind(this));
                 },
-                isAsync: true,
                 message: message
             })
         }
     })
 }
 
-function executeQuery (query, conditions, validateValue, respond) {
+function executeQuery (query, conditions, validateValue, resolve, reject) {
     for (var fieldName in conditions) {
         query.where(fieldName, conditions[fieldName])
     }
     query.exec(function (err, count) {
         if (err) {
-            return respond ? respond(err) : err
+            reject(err)
+            return
         }
-        return respond ? respond(count === validateValue) : count === validateValue
+        return count === validateValue ? resolve(true) : reject(false)
     })
 }
 
 function validateId (
-    doc, connection, refModelName, value, conditions, respond) {
+    doc, connection, refModelName, value, conditions, resolve, reject) {
     if (value == null) {
-        return respond ? respond(true) : true
+        resolve(true)
+        return
     }
     var refModel = connection.model(refModelName)
     var query = refModel.countDocuments({_id: value})
-    executeQuery(query, conditions, 1, respond)
+    executeQuery(query, conditions, 1, resolve, reject)
 }
 
 function validateIdArray (
-    doc, connection, refModelName, values, conditions, respond,
+    doc, connection, refModelName, values, conditions, resolve, reject,
     allowDuplicates) {
     if (values == null || values.length == 0) {
-        return respond ? respond(true) : true
+        resolve(true)
+        return
     }
 
     var checkValues = values
@@ -130,7 +136,7 @@ function validateIdArray (
     var refModel = connection.model(refModelName)
     var query = refModel.countDocuments().where('_id')['in'](checkValues)
 
-    executeQuery(query, conditions, checkValues.length, respond)
+    executeQuery(query, conditions, checkValues.length, resolve, reject)
 }
 
 module.exports = IdValidator.prototype.validate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-id-validator",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Mongoose plugin to validate that ObjectID references refer to objects that actually exist in the referenced collection",
     "author": {
         "name": "Martin Campbell",


### PR DESCRIPTION
This PR refactors the implementation of the async validator. It now uses Promises instead of `isAsync + callback`, as recommended in last mongoose versions.

This PR resolves issue https://github.com/CampbellSoftwareSolutions/mongoose-id-validator/issues/30