### PR TITLE
fix(id-validator): showing custom error message

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -71,7 +71,7 @@ IdValidator.prototype.validateSchema = function (
                         if (!(self instanceof IdValidator) || self.enabled) {
                             if (Object.keys(conditionsCopy).length > 0) {
                                 var instance = this
-    
+
                                 conditionsCopy = clone(conditions)
                                 traverse(conditionsCopy).forEach(function (value) {
                                     if (typeof value === 'function') {
@@ -79,7 +79,7 @@ IdValidator.prototype.validateSchema = function (
                                     }
                                 })
                             }
-    
+
                             return validateFunction(this, connection, refModelName,
                                 value, conditionsCopy, resolve, reject, allowDuplicates)
                         }
@@ -102,7 +102,7 @@ function executeQuery (query, conditions, validateValue, resolve, reject) {
             reject(err)
             return
         }
-        return count === validateValue ? resolve(true) : reject(false)
+        return count === validateValue ? resolve(true) : resolve(false)
     })
 }
 


### PR DESCRIPTION
From Mongoose docs

> There are two ways for an promise-based async validator to fail:
>  1) If the promise rejects, Mongoose assumes the validator failed with the given error.
>  2) If the promise resolves to `false`, Mongoose assumes the validator failed and creates an error with the given `message`.

In our case with boolean value, we must use `resolve` instead `reject`

This PR resolves issue #32 