### PR TITLE
More robust check for if schemaType path is an array

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -42,23 +42,28 @@ IdValidator.prototype.validateSchema = function (
         var validateFunction = null
         var refModelName = null
         var conditions = {}
+        var optionsSource = null
 
         if (schemaType.options && schemaType.options.ref) {
-            validateFunction = validateId
             refModelName = schemaType.options.ref
             if (schemaType.options.refConditions) {
                 conditions = schemaType.options.refConditions
             }
         } else if (schemaType.caster && schemaType.caster.instance &&
             schemaType.caster.options && schemaType.caster.options.ref) {
-            validateFunction = validateIdArray
             refModelName = schemaType.caster.options.ref
             if (schemaType.caster.options.refConditions) {
                 conditions = schemaType.caster.options.refConditions
             }
         }
 
-        if (validateFunction) {
+        var isArraySchemaType =
+            (schemaType.caster && schemaType.caster.instance) ||
+            (schemaType.instance === 'Array') ||
+            (schemaType['$isMongooseArray'] === true)
+        validateFunction = isArraySchemaType ? validateIdArray : validateId
+
+        if (refModelName) {
             schema.path(path).validate({
                 validator: function (value) {
                     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
Fixes #35

The old way of detecting if we needed the array validator didn't handle certain schemaType from mongoose 5.4+. This handles those cases.