### PR TITLE
Adding session support

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -119,6 +119,10 @@ function validateId (
     }
     var refModel = connection.model(refModelName)
     var query = refModel.countDocuments({_id: value})
+    var session = doc.$session && doc.$session()
+    if (session) {
+        query.session(session)
+    }
     executeQuery(query, conditions, 1, resolve, reject)
 }
 
@@ -140,6 +144,10 @@ function validateIdArray (
 
     var refModel = connection.model(refModelName)
     var query = refModel.countDocuments().where('_id')['in'](checkValues)
+    var session = doc.$session && doc.$session()
+    if (session) {
+        query.session(session)
+    }
 
     executeQuery(query, conditions, checkValues.length, resolve, reject)
 }


### PR DESCRIPTION
If the document is associated with a session, run the count query in that session as well.