### PR TITLE
Support Schema references as Model

### DIFF
--- a/lib/id-validator.js
+++ b/lib/id-validator.js
@@ -90,7 +90,9 @@ IdValidator.prototype.validateSchema = function (
                                     }
                                 })
                             }
-                            var localRefModelName = refModelName
+                            var localRefModelName = (!!refModelName.modelName)?
+                              refModelName.modelName :
+                              refModelName
                             if (refModelPath) {
                                 localRefModelName = this[refModelPath]
                             }


### PR DESCRIPTION
Mongoose permits Schema references to be set as String or Model.
[https://mongoosejs.com/docs/api/schematype.html#schematype_SchemaType-ref](https://mongoosejs.com/docs/api/schematype.html#schematype_SchemaType-ref)

This change is to support both scenarios.